### PR TITLE
networking: Create/destroy messages

### DIFF
--- a/packages/pearl-networking/__mocks__/pearl-multiplayer-socket.ts
+++ b/packages/pearl-networking/__mocks__/pearl-multiplayer-socket.ts
@@ -1,0 +1,53 @@
+import {
+  HostSession as RealHostSession,
+  ClientSession as RealClientSession,
+} from 'pearl-multiplayer-socket';
+
+type PublicPart<T> = { [K in keyof T]: T[K] };
+
+export class HostSession implements PublicPart<RealHostSession> {
+  onPeerOpen: (id: string) => void;
+  onPeerClose: (id: string) => void;
+  onPeerMessage: (id: string, msg: any) => void;
+  onGroovejetOpen: () => void;
+
+  getRoomCode(): Promise<string> {
+    return Promise.resolve('roomCode');
+  }
+
+  connectRoom(roomCode: string): void {
+    setTimeout(() => {
+      this.onGroovejetOpen();
+    });
+  }
+
+  sendPeer: (
+    id: string,
+    msg: any,
+    channelLabel?: 'reliable' | 'unreliable'
+  ) => void = jest.fn();
+
+  closePeerConnection(id: string): void {
+    return;
+  }
+}
+
+export class ClientSession implements PublicPart<RealClientSession> {
+  lobbyConnectionState: 'connecting' | 'open' | 'closed';
+  hostConnectionState: 'connecting' | 'open' | 'closed' | 'init';
+
+  onOpen: () => void;
+  onClose: () => void;
+  onMessage: (msg: any) => void;
+
+  connectRoom(roomCode: string): void {
+    setTimeout(() => {
+      this.onOpen();
+    });
+  }
+
+  send: (
+    msg: any,
+    channelLabel?: 'unreliable' | 'reliable' | undefined
+  ) => void = jest.fn();
+}

--- a/packages/pearl-networking/src/components/NetworkedEntity.ts
+++ b/packages/pearl-networking/src/components/NetworkedEntity.ts
@@ -58,8 +58,6 @@ export default class NetworkedEntity extends Component<Opts> {
   }
 
   onDestroy() {
-    if (this.networking) {
-      this.networking.deregisterNetworkedEntity(this.entity);
-    }
+    this.networking.destroyNetworkedEntity(this.entity);
   }
 }

--- a/packages/pearl-networking/src/components/NetworkedEntity.ts
+++ b/packages/pearl-networking/src/components/NetworkedEntity.ts
@@ -6,7 +6,6 @@ import { NetworkedComponent } from '../types';
 interface Opts {
   type: string;
   networking: Networking;
-  id?: string;
 }
 
 type Snapshot = { [key: string]: any };
@@ -20,10 +19,6 @@ export default class NetworkedEntity extends Component<Opts> {
   create(opts: Opts) {
     this.networking = opts.networking;
     this.type = opts.type;
-
-    if (opts.id !== undefined) {
-      this.id = opts.id;
-    }
   }
 
   get isHost() {

--- a/packages/pearl-networking/src/components/Networking.ts
+++ b/packages/pearl-networking/src/components/Networking.ts
@@ -18,7 +18,16 @@ export default abstract class Networking<
     this.prefabs = opts.prefabs;
   }
 
-  protected getPrefab(prefabName: string): NetworkedPrefab {
+  protected instantiateAndRegisterPrefab(
+    prefabName: string,
+    id?: string
+  ): Entity {
+    const entity = this.createEntity(prefabName);
+    this.registerEntity(entity, id);
+    return entity;
+  }
+
+  private getPrefab(prefabName: string): NetworkedPrefab {
     const prefab = this.prefabs[prefabName];
 
     if (!prefab) {
@@ -28,7 +37,9 @@ export default abstract class Networking<
     return prefab;
   }
 
-  protected instantiatePrefab(prefab: NetworkedPrefab, id?: string): Entity {
+  private createEntity(prefabName: string): Entity {
+    const prefab = this.getPrefab(prefabName);
+
     const components = prefab.createComponents(this.pearl);
 
     const entity = new Entity({
@@ -40,17 +51,21 @@ export default abstract class Networking<
         new NetworkedEntity({
           networking: this,
           type: prefab.type,
-          id,
         }),
       ],
     });
 
     this.pearl.entities.add(entity);
 
-    const networked = entity.getComponent(NetworkedEntity);
-    this.networkedEntities.set(networked.id, entity);
-
     return entity;
+  }
+
+  private registerEntity(entity: Entity, id?: string) {
+    const networked = entity.getComponent(NetworkedEntity);
+    if (id) {
+      networked.id = id;
+    }
+    this.networkedEntities.set(networked.id, entity);
   }
 
   abstract destroyNetworkedEntity(entity: Entity): void;

--- a/packages/pearl-networking/src/components/Networking.ts
+++ b/packages/pearl-networking/src/components/Networking.ts
@@ -47,11 +47,11 @@ export default abstract class Networking<
       tags: [prefab.type, ...(prefab.tags || [])],
       zIndex: prefab.zIndex || 0,
       components: [
-        ...components,
         new NetworkedEntity({
           networking: this,
           type: prefab.type,
         }),
+        ...components,
       ],
     });
 

--- a/packages/pearl-networking/src/components/Networking.ts
+++ b/packages/pearl-networking/src/components/Networking.ts
@@ -11,7 +11,7 @@ export default abstract class Networking<
 > extends Component<T> {
   prefabs!: { [_: string]: NetworkedPrefab };
   networkedEntities = new Map<string, Entity>();
-  localPlayerId?: number;
+  localPlayerId?: string;
   abstract isHost: boolean;
 
   protected registerSettings(opts: NetworkingSettings) {
@@ -75,7 +75,7 @@ export default abstract class Networking<
     this.networkedEntities.delete(networked.id);
   }
 
-  protected setIdentity(id: number) {
+  protected setIdentity(id: string) {
     this.localPlayerId = id;
   }
 }

--- a/packages/pearl-networking/src/components/Networking.ts
+++ b/packages/pearl-networking/src/components/Networking.ts
@@ -53,7 +53,9 @@ export default abstract class Networking<
     return entity;
   }
 
-  deregisterNetworkedEntity(entity: Entity) {
+  abstract destroyNetworkedEntity(entity: Entity): void;
+
+  protected deregisterNetworkedEntity(entity: Entity) {
     const networked = entity.getComponent(NetworkedEntity);
     this.networkedEntities.delete(networked.id);
   }

--- a/packages/pearl-networking/src/components/NetworkingClient.ts
+++ b/packages/pearl-networking/src/components/NetworkingClient.ts
@@ -132,6 +132,13 @@ export default class NetworkingClient extends Networking<NetworkingSettings> {
   private deserializeEntity(snapshot: EntitySnapshot) {
     const entity = this.networkedEntities.get(snapshot.id)!;
 
+    if (!entity) {
+      console.warn(
+        `snapshot contained nonexistent entity: ${snapshot.type}/${snapshot.id}`
+      );
+      return;
+    }
+
     entity
       .getComponent(NetworkedEntity)
       .clientDeserialize(snapshot.state, this.networkedEntities);

--- a/packages/pearl-networking/src/components/NetworkingClient.ts
+++ b/packages/pearl-networking/src/components/NetworkingClient.ts
@@ -69,6 +69,8 @@ export default class NetworkingClient extends Networking<NetworkingSettings> {
       this.onEntityCreate(msg.data);
     } else if (msg.type === 'entityDestroy') {
       this.onEntityDestroy(msg.data);
+    } else if (msg.type === 'initialSnapshot') {
+      this.onInitialSnapshot(msg.data);
     }
     // else if (msg.type === 'ping') {
     // this.sendToHost({
@@ -148,6 +150,18 @@ export default class NetworkingClient extends Networking<NetworkingSettings> {
       return;
     }
     this.snapshotClock = clock;
+
+    for (let snapshotEntity of snapshot.entities) {
+      this.deserializeEntity(snapshotEntity);
+    }
+  }
+
+  private onInitialSnapshot(snapshot: SnapshotMessageData) {
+    this.snapshotClock = snapshot.clock;
+
+    for (let snapshotEntity of snapshot.entities) {
+      this.instantiateAndRegisterPrefab(snapshotEntity.type, snapshotEntity.id);
+    }
 
     for (let snapshotEntity of snapshot.entities) {
       this.deserializeEntity(snapshotEntity);

--- a/packages/pearl-networking/src/components/NetworkingClient.ts
+++ b/packages/pearl-networking/src/components/NetworkingClient.ts
@@ -117,8 +117,7 @@ export default class NetworkingClient extends Networking<NetworkingSettings> {
   }
 
   private onEntityCreate(snapshot: EntitySnapshot) {
-    const prefab = this.getPrefab(snapshot.type);
-    this.instantiatePrefab(prefab, snapshot.id);
+    this.instantiateAndRegisterPrefab(snapshot.type, snapshot.id);
     this.deserializeEntity(snapshot);
   }
 

--- a/packages/pearl-networking/src/components/NetworkingClient.ts
+++ b/packages/pearl-networking/src/components/NetworkingClient.ts
@@ -122,6 +122,10 @@ export default class NetworkingClient extends Networking<NetworkingSettings> {
   }
 
   private onEntityDestroy({ id }: EntityDestroyData) {
+    if (!this.networkedEntities.has(id)) {
+      return;
+    }
+
     this.pearl.entities.destroy(this.networkedEntities.get(id)!);
   }
 

--- a/packages/pearl-networking/src/components/NetworkingHost.ts
+++ b/packages/pearl-networking/src/components/NetworkingHost.ts
@@ -159,6 +159,11 @@ export default class NetworkingHost extends Networking<Settings> {
         id: player.id,
       },
     });
+
+    this.sendToPeer(peerId, {
+      type: 'initialSnapshot',
+      data: this.serializeSnapshot(),
+    });
   }
 
   private onPeerMessage(peerId: string, data: string) {

--- a/packages/pearl-networking/src/components/NetworkingHost.ts
+++ b/packages/pearl-networking/src/components/NetworkingHost.ts
@@ -144,6 +144,11 @@ export default class NetworkingHost extends Networking<Settings> {
       return;
     }
 
+    this.sendToPeer(peerId, {
+      type: 'initialSnapshot',
+      data: this.serializeSnapshot(),
+    });
+
     const player = this.addPlayer({
       inputter: new NetworkedInputter(),
     });
@@ -155,11 +160,6 @@ export default class NetworkingHost extends Networking<Settings> {
       data: {
         id: player.id,
       },
-    });
-
-    this.sendToPeer(peerId, {
-      type: 'initialSnapshot',
-      data: this.serializeSnapshot(),
     });
   }
 

--- a/packages/pearl-networking/src/components/NetworkingHost.ts
+++ b/packages/pearl-networking/src/components/NetworkingHost.ts
@@ -210,18 +210,6 @@ export default class NetworkingHost extends Networking<Settings> {
     this.onPlayerRemoved.call({ networkingPlayer: player });
   }
 
-  update(dt: number) {
-    const snapshot = this.serializeSnapshot();
-
-    this.sendAll(
-      {
-        type: 'snapshot',
-        data: snapshot,
-      },
-      'unreliable'
-    );
-  }
-
   lateUpdate() {
     for (let player of this.players.values()) {
       if (player.inputter instanceof NetworkedInputter) {
@@ -237,6 +225,16 @@ export default class NetworkingHost extends Networking<Settings> {
     }
 
     this.createdEntitiesQueue = [];
+
+    const snapshot = this.serializeSnapshot();
+
+    this.sendAll(
+      {
+        type: 'snapshot',
+        data: snapshot,
+      },
+      'unreliable'
+    );
   }
 
   private onClientKeyDown(player: NetworkingPlayer, keyCode: number) {

--- a/packages/pearl-networking/src/components/__tests__/NetworkingClient.spec.ts
+++ b/packages/pearl-networking/src/components/__tests__/NetworkingClient.spec.ts
@@ -1,0 +1,127 @@
+import { Entity, Component, createTestPearl, PearlInstance } from 'pearl';
+jest.mock('pearl/dist/AudioManager');
+
+import NetworkingClient from '../NetworkingClient';
+import { NetworkedComponent } from '../../types';
+import { EntityCreateMessage, EntityDestroyMessage } from '../../messages';
+import NetworkedEntity from '../NetworkedEntity';
+
+jest.mock('pearl-multiplayer-socket', () => {
+  class ClientSession {
+    connectRoom() {
+      return Promise.resolve();
+    }
+  }
+
+  return {
+    ClientSession,
+  };
+});
+
+interface TestComponentSnapshot {
+  a: number;
+}
+
+class TestComponent extends Component<void>
+  implements NetworkedComponent<TestComponentSnapshot> {
+  a = 0;
+
+  create() {
+    this.a = 1;
+  }
+
+  serialize() {
+    return { a: this.a };
+  }
+
+  deserialize(snapshot: TestComponentSnapshot) {
+    this.a = snapshot.a;
+  }
+}
+
+async function setup() {
+  const client = new NetworkingClient({
+    prefabs: {
+      examplePrefab: {
+        type: 'examplePrefab',
+        createComponents: () => [new TestComponent()],
+      },
+    },
+  });
+
+  const pearl = await createTestPearl({
+    rootComponents: [client],
+  });
+
+  return client;
+}
+
+async function createTestEntity(client: NetworkingClient) {
+  const msg: EntityCreateMessage = {
+    type: 'entityCreate',
+    data: {
+      id: '1234',
+      parentId: undefined,
+      state: {
+        TestComponent: {
+          a: 1,
+        },
+      },
+      type: 'examplePrefab',
+    },
+  };
+
+  const promise = client.connect({
+    roomCode: '',
+    groovejetUrl: '',
+  });
+  client['connection'].onOpen();
+  await promise;
+
+  client['connection'].onMessage(JSON.stringify(msg));
+}
+
+function getTestEntity(pearl: PearlInstance): Entity | undefined {
+  // TODO: This currently gets the entities as a set so it can check if the
+  // entity got added before it was instantiated. There should really be a
+  // getEntityByName or some shit for this instead :\
+  const entitiesSet: Set<Entity> = pearl.entities['_entities'];
+
+  const entity = [...entitiesSet].filter((entity) => {
+    const networked = entity.maybeGetComponent(NetworkedEntity);
+    if (networked) {
+      return networked.id === '1234';
+    }
+    return false;
+  })[0];
+
+  return entity;
+}
+
+describe('NetworkingClient', () => {
+  it('creates entity when entityCreate message is received', async () => {
+    const client = await setup();
+    await createTestEntity(client);
+
+    const entity = getTestEntity(client.pearl);
+    expect(entity).toBeDefined();
+    expect(entity!.getComponent(TestComponent).a).toBe(1);
+  });
+
+  it('destroys entity when entityDestroy message is received', async () => {
+    const client = await setup();
+    await createTestEntity(client);
+
+    const msg: EntityDestroyMessage = {
+      type: 'entityDestroy',
+      data: {
+        id: '1234',
+      },
+    };
+
+    client['connection'].onMessage(JSON.stringify(msg));
+
+    const entity = getTestEntity(client.pearl);
+    expect(entity).toBeUndefined();
+  });
+});

--- a/packages/pearl-networking/src/components/__tests__/NetworkingHost.spec.ts
+++ b/packages/pearl-networking/src/components/__tests__/NetworkingHost.spec.ts
@@ -1,0 +1,87 @@
+import { Entity, Component, createTestPearl } from 'pearl';
+jest.mock('pearl/dist/AudioManager');
+
+import NetworkingHost from '../NetworkingHost';
+import { NetworkedComponent } from '../../types';
+import { EntityCreateMessage, EntityDestroyMessage } from '../../messages';
+import NetworkedEntity from '../NetworkedEntity';
+
+interface TestComponentSnapshot {
+  a: number;
+}
+
+class TestComponent extends Component<void>
+  implements NetworkedComponent<TestComponentSnapshot> {
+  a = 0;
+
+  create() {
+    this.a = 1;
+  }
+
+  serialize() {
+    return { a: this.a };
+  }
+
+  deserialize(snapshot: TestComponentSnapshot) {
+    this.a = snapshot.a;
+  }
+}
+
+async function setup() {
+  const host = new NetworkingHost({
+    prefabs: {
+      examplePrefab: {
+        type: 'examplePrefab',
+        createComponents: () => [new TestComponent()],
+      },
+    },
+  });
+
+  const pearl = await createTestPearl({
+    rootComponents: [host],
+  });
+
+  return host;
+}
+
+describe('NetworkingHost', () => {
+  it('sends creation messages on entity creation', async () => {
+    const host = await setup();
+    const mockSendAll = (host['sendAll'] = jest.fn());
+
+    const prefab = host.createNetworkedPrefab('examplePrefab');
+
+    const expectedMsg: EntityCreateMessage = {
+      type: 'entityCreate',
+      data: {
+        id: prefab.getComponent(NetworkedEntity).id,
+        parentId: undefined,
+        state: {
+          TestComponent: {
+            a: 1,
+          },
+        },
+        type: 'examplePrefab',
+      },
+    };
+
+    expect(mockSendAll.mock.calls[0][0]).toEqual(expectedMsg);
+  });
+
+  it('sends destroy messages on entity destruction', async () => {
+    const host = await setup();
+    const mockSendAll = (host['sendAll'] = jest.fn());
+
+    const prefab = host.createNetworkedPrefab('examplePrefab');
+    host.pearl.entities.destroy(prefab);
+
+    const expectedMsg: EntityDestroyMessage = {
+      type: 'entityDestroy',
+      data: {
+        id: prefab.getComponent(NetworkedEntity).id,
+      },
+    };
+
+    expect(mockSendAll.mock.calls[1][0]).toEqual(expectedMsg);
+  });
+});

--- a/packages/pearl-networking/src/components/__tests__/NetworkingHost.spec.ts
+++ b/packages/pearl-networking/src/components/__tests__/NetworkingHost.spec.ts
@@ -65,6 +65,8 @@ describe('NetworkingHost', () => {
       },
     };
 
+    host.pearl.ticker.step(0);
+
     expect(mockSendAll.mock.calls[0][0]).toEqual(expectedMsg);
   });
 
@@ -73,6 +75,8 @@ describe('NetworkingHost', () => {
     const mockSendAll = (host['sendAll'] = jest.fn());
 
     const prefab = host.createNetworkedPrefab('examplePrefab');
+    host.pearl.ticker.step(0);
+
     host.pearl.entities.destroy(prefab);
 
     const expectedMsg: EntityDestroyMessage = {
@@ -82,6 +86,6 @@ describe('NetworkingHost', () => {
       },
     };
 
-    expect(mockSendAll.mock.calls[1][0]).toEqual(expectedMsg);
+    expect(mockSendAll.mock.calls[2][0]).toEqual(expectedMsg);
   });
 });

--- a/packages/pearl-networking/src/messages.ts
+++ b/packages/pearl-networking/src/messages.ts
@@ -33,7 +33,7 @@ export interface SnapshotMessage extends BaseMessage {
 }
 
 export interface IdentityMessageData {
-  id: number;
+  id: string;
 }
 
 export interface IdentityMessage extends BaseMessage {

--- a/packages/pearl-networking/src/messages.ts
+++ b/packages/pearl-networking/src/messages.ts
@@ -45,11 +45,27 @@ export interface TooManyPlayersMessage extends BaseMessage {
   type: 'tooManyPlayers';
 }
 
+export interface EntityCreateMessage extends BaseMessage {
+  type: 'entityCreate';
+  data: EntitySnapshot;
+}
+
+export interface EntityDestroyData {
+  id: string;
+}
+
+export interface EntityDestroyMessage extends BaseMessage {
+  type: 'entityDestroy';
+  data: EntityDestroyData;
+}
+
 export type ServerMessage =
   | RpcMessage
   | SnapshotMessage
   | IdentityMessage
-  | TooManyPlayersMessage;
+  | TooManyPlayersMessage
+  | EntityCreateMessage
+  | EntityDestroyMessage;
 
 export interface InputKeyMessageData {
   keyCode: number;

--- a/packages/pearl-networking/src/messages.ts
+++ b/packages/pearl-networking/src/messages.ts
@@ -59,13 +59,19 @@ export interface EntityDestroyMessage extends BaseMessage {
   data: EntityDestroyData;
 }
 
+export interface InitialSnapshotMessage extends BaseMessage {
+  type: 'initialSnapshot';
+  data: SnapshotMessageData;
+}
+
 export type ServerMessage =
   | RpcMessage
   | SnapshotMessage
   | IdentityMessage
   | TooManyPlayersMessage
   | EntityCreateMessage
-  | EntityDestroyMessage;
+  | EntityDestroyMessage
+  | InitialSnapshotMessage;
 
 export interface InputKeyMessageData {
   keyCode: number;

--- a/packages/pearl/src/Entity.ts
+++ b/packages/pearl/src/Entity.ts
@@ -212,12 +212,20 @@ export default class Entity {
   }
 
   update(dt: number) {
+    if (this.state !== 'initialized') {
+      return;
+    }
+
     for (let component of this.components) {
       component.update(dt);
     }
   }
 
   lateUpdate() {
+    if (this.state !== 'initialized') {
+      return;
+    }
+
     for (let component of this.components) {
       component.lateUpdate();
     }

--- a/packages/pearl/src/index.ts
+++ b/packages/pearl/src/index.ts
@@ -79,3 +79,5 @@ export {
   ITileMap,
   TileCollisionType,
 } from './components/tilemap/TileMapCollider';
+
+export { default as createTestPearl } from './util/createTestPearl';

--- a/packages/pearl/src/util/createTestPearl.ts
+++ b/packages/pearl/src/util/createTestPearl.ts
@@ -1,0 +1,21 @@
+import PearlInstance, { CreatePearlOpts } from '../PearlInstance';
+
+export default async function createTestPearl(
+  opts: Partial<CreatePearlOpts>
+): Promise<PearlInstance> {
+  const defaultOpts: CreatePearlOpts = {
+    canvas: document.createElement('canvas'),
+    width: 100,
+    height: 100,
+    rootComponents: [],
+  };
+
+  const finalOpts = { ...defaultOpts, ...opts };
+
+  const game = new PearlInstance();
+
+  await game.loadAssets(opts.assets || {});
+  game.run(finalOpts);
+
+  return game;
+}


### PR DESCRIPTION
implements #2 

TODO:

- [x] Test with Sledgehammer
- [x] Add specs
  - [x] On host, message is sent when entity created including snapshot state
  - [x] On host, message is sent when entity destroyed
  - [x] On client, entity is created with snapshot when create message is received
  - [x]  On client, entity is destroy when destroy message is received
  - [x] On host, initial snapshot is sent to client on connect
  - [x] On client, initial snapshot is applied when received
- [x] Clean up file ordering a whole lot
- [x] Fix sending destroy messages for children when parent is destroyed
  - Maybe will require something like a `destroyQueue = new Set<Entity>()`
  - Filter out any children who's parents are already being removed: `const destroyed = destroyQueue.filter((entity) => !destroyQueue.has(entity.parentId))` 